### PR TITLE
Add missing rumps dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sounddevice>=0.4.6
 numpy>=1.20.0
+rumps>=0.4.0


### PR DESCRIPTION
## Summary
- Adds `rumps>=0.4.0` to requirements.txt
- Fixes #1 - resolves missing dependency issue when users try to run the project

## Test plan
- [x] Verify rumps is listed in requirements.txt
- [x] Test that `pip install -r requirements.txt` installs all required dependencies including rumps
- [x] Confirm the application runs without missing module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)